### PR TITLE
docs(README): correct the lexicon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use](https://saifmohammad.com/WebPages/NRC-Emotion-Lexicon.htm)
 > French Expanded Emotion Lexicon. Language Resources and Evaluation,
 > LRE 2016, pp 1-23.
 
-<http://www.lirmm.fr/~abdaoui/FEEL>
+<http://advanse.lirmm.fr/feel.php>
 
 ## Installation
 


### PR DESCRIPTION
The lexicon link is no longer accessible on my old personal home page.
I suggest this pull request with the correct link on the lab website.